### PR TITLE
Disable recursive route check for GCE compatibility.

### DIFF
--- a/sysdep/linux/netlink.c
+++ b/sysdep/linux/netlink.c
@@ -359,8 +359,7 @@ nl_parse_multipath(struct krt_proto *p, struct rtattr *ra)
 	  memcpy(&rv->gw, RTA_DATA(a[RTA_GATEWAY]), sizeof(ip_addr));
 	  ipa_ntoh(rv->gw);
 
-	  neighbor *ng = neigh_find2(&p->p, &rv->gw, rv->iface,
-				     (nh->rtnh_flags & RTNH_F_ONLINK) ? NEF_ONLINK : 0);
+	  neighbor *ng = neigh_find2(&p->p, &rv->gw, rv->iface, NEF_ONLINK);
 	  if (!ng || (ng->scope == SCOPE_HOST))
 	    return NULL;
 	}
@@ -874,8 +873,7 @@ nl_parse_route(struct nlmsghdr *h, int scan)
 	    return;
 #endif
 
-	  ng = neigh_find2(&p->p, &ra.gw, ra.iface,
-			   (i->rtm_flags & RTNH_F_ONLINK) ? NEF_ONLINK : 0);
+	  ng = neigh_find2(&p->p, &ra.gw, ra.iface, NEF_ONLINK);
 	  if (!ng || (ng->scope == SCOPE_HOST))
 	    {
 	      log(L_ERR "KRT: Received route %I/%d with strange next-hop %I",


### PR DESCRIPTION
GCE uses a /32 for VM IPs with a default gateway that is, thus,
off-subnet.  This patch removes a check in BIRD that prevents
BIRD from accepting such a route as a valid next hop.

The following trail asserts that the check is not really needed
but that it is normally a useful sanity check:

https://www.mail-archive.com/bird-users@atrey.karlin.mff.cuni.cz/msg02600.html

Ideally GCE would set the onlink flag on the route or use a
link-local IP instead but that is unlikely to change.
