### PR TITLE
Fix change detection logic for tunnel routes.

### DIFF
--- a/sysdep/unix/krt.c
+++ b/sysdep/unix/krt.c
@@ -730,9 +730,12 @@ krt_got_route(struct krt_proto *p, rte *e)
 
       if (!new)
 	verdict = KRF_DELETE;
-      else if ((net->n.flags & KRF_SYNC_ERROR) || !krt_same_dest(e, new))
+      else if ((net->n.flags & KRF_SYNC_ERROR))
 	verdict = KRF_UPDATE;
-      else
+      else if (tmpa &&
+	  (e->attrs->dest == RTD_ROUTER) &&
+	  (ea = ea_find(tmpa, EA_KRT_TUNNEL)) &&
+	  (i = if_find_by_name(ea->u.ptr->data)))
 	{
 	  /* Calico-BIRD specific: we check if the export filter set a tunnel
 	   * attribute for the route.  If it did, and the tunnel interface is
@@ -740,15 +743,15 @@ krt_got_route(struct krt_proto *p, rte *e)
 	   * for the route, generate KRF_UPDATE here so that the route gets
 	   * updated to have the tunnel as its outgoing interface.
 	   */
-	  if (tmpa &&
-	      (e->attrs->dest == RTD_ROUTER) &&
-	      (ea = ea_find(tmpa, EA_KRT_TUNNEL)) &&
-	      (i = if_find_by_name(ea->u.ptr->data)) &&
-	      strcmp(i->name, e->attrs->iface->name))
+	   if(strcmp(i->name, e->attrs->iface->name) || !ipa_equal(e->attrs->gw, new->attrs->from))
 	    verdict = KRF_UPDATE;
 	  else
 	    verdict = KRF_SEEN;
 	}
+	else if(!krt_same_dest(e, new))
+	  verdict = KRF_UPDATE;
+	else
+	  verdict = KRF_SEEN;
 
       if (rt_free)
 	rte_free(rt_free);


### PR DESCRIPTION

How to reproduce the bug:

- Setup calico using `ipip`
- Run `ip monitor` on a node. 
- You will see all the tunnel routes to the other nodes are deleted and readded every second.

Cause of the bug: 

When a tunnel route gets added to the kernel, the gateway gets replaced
with the source IP, and the interface gets replaced with the tunnel
interface. The change detection wasn't taking this into account, causing
krt_same_dest return false, and the route would get deleted and
readded constantly.

This commit fixes it by not doing the krt_same_dest check for tunnel
routes, doing its own checks instead.
