### PR TITLE
Fully specify the copy destination.

### DIFF
--- a/create_binaries.sh
+++ b/create_binaries.sh
@@ -8,13 +8,13 @@ make
 rm bird birdcl
 make CC="gcc -static"
 cp bird dist/bird6
-cp birdcl dist
+cp birdcl dist/birdcl
 
 # Rerun the build but without IPv6 (or the client) and store off the result.
 make clean
 ./configure  --with-protocols="bgp pipe static" --enable-client=no --enable-pthreads=yes
 make
-rm bird 
+rm bird
 make CC="gcc -static"
 cp bird dist/bird
 


### PR DESCRIPTION
If the build is done outside of a docker container by directly executing
the create_binaries.sh script, the `cp birdcl dist` command actually
overwrites the dist directory with the birdcl binary.

This is a bugfix. 

If this PR is merges the create_binaries script can be executed on a native os outside of a docker container. 

Tested manually. 

## Description
A few sentences describing the overall goals of the pull request's commits. 
Please include 
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR

## Todos
- [ ] Unit tests (full coverage)
- [ ] Integration tests (delete as appropriate) In plan/Not needed/Done
- [ ] Documentation
- [ ] Backport
