### PR TITLE
Add KDD datastore backend

### DIFF
--- a/build_routereflector/image/install.sh
+++ b/build_routereflector/image/install.sh
@@ -36,7 +36,7 @@ $minimal_apt_get_install \
         bird6
 
 # Install Confd
-curl -L https://www.github.com/kelseyhightower/confd/releases/download/v0.9.0/confd-0.9.0-linux-amd64 -o confd
+curl -L https://github.com/projectcalico/confd/releases/download/v0.12.1-calico0.2.0/confd -o confd
 chmod +x confd
 
 # Create the config directory for confd

--- a/build_routereflector/node_filesystem/conf.d/bird.toml
+++ b/build_routereflector/node_filesystem/conf.d/bird.toml
@@ -2,6 +2,6 @@
 src = "bird.cfg.template"
 dest = "/config/bird.cfg"
 prefix = "/calico/bgp/v1"
-keys = ["/"]
+keys = ["/rr_v4", "/global", "/host"]
 check_cmd = "bird -p -c {{.src}}"
 reload_cmd = "pkill -HUP bird || true"

--- a/build_routereflector/node_filesystem/etc/service/confd/run
+++ b/build_routereflector/node_filesystem/etc/service/confd/run
@@ -1,12 +1,16 @@
 #!/bin/sh
 
-# Use ETCD_ENDPOINTS in preferences to ETCD_AUTHORITY
-ETCD_NODE=${ETCD_ENDPOINTS:=${ETCD_SCHEME:=http}://${ETCD_AUTHORITY}}
-
-# confd needs a "-node" arguments for each etcd endpoint.
-ETCD_ENDPOINTS_CONFD=`echo "-node=$ETCD_NODE" | sed -e 's/,/ -node=/g'`
-
+#!/bin/sh
 exec 2>&1
-exec /confd -confdir=/ -interval=5 -watch --log-level=debug \
-     -client-key=${ETCD_KEY_FILE} -client-cert=${ETCD_CERT_FILE} \
-     -client-ca-keys=${ETCD_CA_CERT_FILE} $ETCD_ENDPOINTS_CONFD
+
+if [ "$DATASTORE_TYPE" = "kubernetes" ]
+then
+    exec /confd -confdir=/ -interval=5 -log-level=debug -backend=k8s -kubeconfig=$KUBECONFIG
+else
+    ETCD_NODE=${ETCD_ENDPOINTS:=${ETCD_SCHEME:=http}://${ETCD_AUTHORITY}}
+    ETCD_ENDPOINTS_CONFD=`echo "-node=$ETCD_NODE" | sed -e 's/,/ -node=/g'`
+
+    exec /confd -confdir=/ -interval=5 -watch --log-level=debug \
+           $ETCD_ENDPOINTS_CONFD -client-key=${ETCD_KEY_FILE} \
+           -client-cert=${ETCD_CERT_FILE} -client-ca-keys=${ETCD_CA_CERT_FILE}
+fi

--- a/build_routereflector/node_filesystem/templates/bird.cfg.template
+++ b/build_routereflector/node_filesystem/templates/bird.cfg.template
@@ -20,7 +20,6 @@ template bgp bgp_template {
 
 {{$our_rr_key := printf "/rr_v4/%s" (getenv "IP")}}
 {{if ls $our_rr_key}}{{$our_rr_data := json (getv $our_rr_key)}}
-
 # ------------- RR-to-RR full mesh -------------
 {{if ls "/rr_v4"}}
 {{range gets "/rr_v4/*"}}{{$data := json .Value}}{{$rr_ip := $data.ip}}
@@ -71,6 +70,48 @@ protocol bgp Node_{{$id}} from bgp_template {
   neighbor {{$cnode_ip}} as {{if exists $cnode_as_key}}{{getv $cnode_as_key}}{{else}}{{getv "/global/as_num"}}{{end}};
   rr client;
   {{if $our_rr_data.cluster_id}}rr cluster id {{$our_rr_data.cluster_id}};{{end}}
+}
+{{end}}
+{{end}}
+{{end}}
+{{end}}
+{{else}}
+# --------------- Standalone RR -----------------
+# ------------- RR as a global peer -------------
+{{if ls "/global/peer_v4"}}
+{{range gets "/global/peer_v4/*"}}{{$data := json .Value}}
+{{if eq $data.ip (getenv "IP")}}
+# This RR is a global peer with *all* calico nodes.
+{{range $cnode := lsdir "/host"}}
+{{$cnode_as_key := printf "/host/%s/as_num" $cnode}}
+{{$cnode_ip_key := printf "/host/%s/ip_addr_v4" $cnode}}{{$cnode_ip := getv $cnode_ip_key}}
+{{$nums := split $cnode_ip "."}}{{$id := join $nums "_"}}
+# Peering with Calico node {{$cnode}}
+protocol bgp Global_{{$id}} from bgp_template {
+  local as {{$data.as_num}};
+  neighbor {{$cnode_ip}} as {{if exists $cnode_as_key}}{{getv $cnode_as_key}}{{else}}{{getv "/global/as_num"}}{{end}};
+  rr client;
+}
+{{end}}
+{{end}}
+{{end}}
+{{end}}
+
+
+# ------------- RR as a node-specific peer -------------
+{{range $cnode := lsdir "/host"}}
+{{$node_peers_key := printf "/host/%s/peer_v4" $cnode}}
+{{if ls $node_peers_key}}
+{{range $peer := gets (printf "%s/*" $node_peers_key)}}{{$data := json $peer.Value}}
+{{if eq $data.ip (getenv "IP")}}
+{{$cnode_as_key := printf "/host/%s/as_num" $cnode}}
+{{$cnode_ip_key := printf "/host/%s/ip_addr_v4" $cnode}}{{$cnode_ip := getv $cnode_ip_key}}
+{{$nums := split $cnode_ip "."}}{{$id := join $nums "_"}}
+# RR configured as a specific peer for calico node {{$peer.Key}}
+protocol bgp Node_{{$id}} from bgp_template {
+  local as {{$data.as_num}};
+  neighbor {{$cnode_ip}} as {{if exists $cnode_as_key}}{{getv $cnode_as_key}}{{else}}{{getv "/global/as_num"}}{{end}};
+  rr client;
 }
 {{end}}
 {{end}}


### PR DESCRIPTION
Add KDD as a possible backend for the Route Reflector image.

Without further changes to confd it is not possible to support a RR cluster, so these changes only allow you to create a single standalone Route Reflector. However, this is still useful for testing KDD routing with global and node-specific peerings.