### PR TITLE
Auto-insert etcd entries

### DIFF
--- a/build_routereflector/image/cleanup.sh
+++ b/build_routereflector/image/cleanup.sh
@@ -5,8 +5,8 @@ set -x
 # Remove extra packages using dpkg rather than apt-get - this prevents us from
 # deleting dependent packages that we still require.
 # - Remove any temporary packages installed in the install.sh script.
-echo "Removing extra packages"
-cat /tmp/add-apt.txt | xargs xargs dpkg -r --force-depends
+#echo "Removing extra packages"
+#cat /tmp/add-apt.txt | xargs xargs dpkg -r --force-depends
 
 # Remove any other junk created during installation that is not required.
 apt-get clean

--- a/build_routereflector/image/install.sh
+++ b/build_routereflector/image/install.sh
@@ -16,9 +16,6 @@ $minimal_apt_get_install apt-transport-https ca-certificates
 # Install add-apt-repository
 $minimal_apt_get_install software-properties-common
 
-# Install curl, needed below for manual BIRD install.
-$minimal_apt_get_install curl
-
 # Find the list of packages just installed - these can be deleted later.
 grep -Fxvf  /tmp/base.txt <(dpkg -l | grep ^ii | sed 's_  _\t_g' | cut \
 -f 2) >/tmp/add-apt.txt
@@ -26,6 +23,11 @@ grep -Fxvf  /tmp/base.txt <(dpkg -l | grep ^ii | sed 's_  _\t_g' | cut \
 # Add new repos and update again
 LC_ALL=C.UTF-8 LANG=C.UTF-8 add-apt-repository -y ppa:cz.nic-labs/bird
 apt-get update
+
+# Install curl, needed below for manual BIRD install, and for auto-inserting
+# etcd entries for the RR.  It might be better in future to add a static build
+# of etcdctl and then remove curl and other unused installed packages.
+$minimal_apt_get_install curl
 
 # Install packages that should not be removed in the cleanup processing.
 # - bird and bird6

--- a/build_routereflector/node_filesystem/etc/rc.local
+++ b/build_routereflector/node_filesystem/etc/rc.local
@@ -2,6 +2,32 @@
 # Record current boot time. Helps with debugging.
 date > /tmp/boottime.txt
 
-# Run Confd in onetime mode, to ensure that we have a working config in place
-# to allow bird(s) to start.
-#./confd -confdir=. -onetime -node ${ETCD_AUTHORITY}
+# If running with etcd, make sure we initialize the paths required by confd
+if [ "$DATASTORE_TYPE" != "kubernetes" ]
+then
+    ETCD_NODE=${ETCD_ENDPOINTS:=${ETCD_SCHEME:=http}://${ETCD_AUTHORITY}}
+    ETCD_ENDPOINT=`echo "$ETCD_NODE" | cut -d "," -f1`
+
+    if [ `echo "$ETCD_ENDPOINT" | cut -d ":" -f1` = "https" ]
+    then
+        CURL_CMD="curl --cacert ${ETCD_CA_CERT_FILE} --cert ${ETCD_CERT_FILE} --key ${ETCD_KEY_FILE}"
+    else
+        CURL_CMD="curl"
+    fi
+
+    # Create the watch keys as bare minimum to get bgp running
+    $CURL_CMD ${ETCD_ENDPOINT}/v2/keys/calico/bgp/v1/rr_v4 -XPUT -d dir=true -d prevExist=false
+    $CURL_CMD ${ETCD_ENDPOINT}/v2/keys/calico/bgp/v1/rr_v6 -XPUT -d dir=true -d prevExist=false
+    $CURL_CMD ${ETCD_ENDPOINT}/v2/keys/calico/bgp/v1/global -XPUT -d dir=true -d prevExist=false
+    $CURL_CMD ${ETCD_ENDPOINT}/v2/keys/calico/bgp/v1/host -XPUT -d dir=true -d prevExist=false
+
+    # Add an entry into etcd for the RR
+    if [ "$CLUSTER_ID" != "" ]
+    then
+        $CURL_CMD ${ETCD_ENDPOINT}/v2/keys/calico/rr_v4/${IP} -XPUT -d value="{\"ip\":\"${IP}\",\"cluster_id\":\"${CLUSTER_ID}\"}"
+    else
+        $CURL_CMD ${ETCD_ENDPOINT}/v2/keys/calico/rr_v4/${IP} -XPUT -d value="{\"ip\":\"${IP}\"}"
+    fi
+fi
+
+true


### PR DESCRIPTION
Auto-install the IPv4 RR entries that need to be added to get clusters working correctly.

Previously this was handled by separate installation steps, but since we needed to add some etcd entries to work around a change in behavior from the previous release.