### PR TITLE
Adding support for ppc64le and multi-arch builds.

### DIFF
--- a/Dockerfile-ppc64le
+++ b/Dockerfile-ppc64le
@@ -1,0 +1,7 @@
+FROM ppc64le/alpine:latest
+MAINTAINER Tom Denham <tom@projectcalico.org>
+
+RUN apk update
+RUN apk add alpine-sdk linux-headers autoconf flex bison ncurses-dev readline-dev 
+
+WORKDIR /code

--- a/build.sh
+++ b/build.sh
@@ -1,4 +1,22 @@
-docker build -t birdbuild .
-mkdir -p dist
-docker run --name bird-build -v `pwd`:/code birdbuild ./create_binaries.sh
+#!/bin/bash
+###############################################################################
+# The build architecture is select by setting the ARCH variable.
+# For example: When building on ppc64le you could use ARCH=ppc64le ./build.sh.
+# When ARCH is undefined it defaults to amd64.
+###############################################################################
+[ ! $ARCH ] &&  ARCH=amd64
+
+if [ $ARCH = amd64 ]; then
+	unset ARCHTAG
+fi
+
+if [ $ARCH = ppc64le ]; then
+	ARCHTAG=-ppc64le
+fi
+
+DIST=dist/$ARCH
+
+docker build -t birdbuild$ARCHTAG -f Dockerfile$ARCHTAG . 
+mkdir -p $DIST
+docker run --name bird-build -e ARCH=$ARCH -e DIST=$DIST -v `pwd`:/code birdbuild$ARCHTAG ./create_binaries.sh
 docker rm -f bird-build || true

--- a/create_binaries.sh
+++ b/create_binaries.sh
@@ -1,20 +1,25 @@
 #!/bin/sh
+
+[ ! $ARCH ] && echo ERROR: ARCH is not set. && exit 1
+[ ! $DIST ] && echo ERROR: DIST is not set. && exit 1
+
+
 autoconf
 # Configure just the protocols we need, and enable the client and IPv6
-./configure  --with-protocols="bgp pipe static" --enable-ipv6=yes --enable-client=yes --enable-pthreads=yes
+./configure  --with-protocols="bgp pipe static" --enable-ipv6=yes --enable-client=yes --enable-pthreads=yes --with-sysconfig=linux-v6 --build=$ARCH
 make
 
 # Remove the dynmaic binaries and rerun make to create static binaries and store off the results
 rm bird birdcl
 make CC="gcc -static"
-cp bird dist/bird6
-cp birdcl dist/birdcl
+cp bird $DIST/bird6
+cp birdcl $DIST/birdcl
 
 # Rerun the build but without IPv6 (or the client) and store off the result.
 make clean
-./configure  --with-protocols="bgp pipe static" --enable-client=no --enable-pthreads=yes
+./configure  --with-protocols="bgp pipe static" --enable-client=no --enable-pthreads=yes -with-sysconfig=linux --build=$ARCH
 make
 rm bird
 make CC="gcc -static"
-cp bird dist/bird
+cp bird $DIST/bird
 


### PR DESCRIPTION
The build architecture is select by setting the ARCH environment
variable. For example: When building on ppc64le you could use:
ARCH=ppc64le ./build.sh.

When ARCH is undefined builds defaults to amd64.

Signed-off-by: David Wilder <wilder@us.ibm.com>

## Description
Adding support for multi-arch builds of bird.
Artifacts are now created in dist/$ARCH.
