### PR TITLE
Adding support for ppc64le and multi-arch builds of the routereflector.

### DIFF
--- a/build_routereflector/Dockerfile-ppc64le
+++ b/build_routereflector/Dockerfile-ppc64le
@@ -1,0 +1,49 @@
+# Copyright 2015 Tigera, Inc
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# For details and docs - see https://github.com/phusion/baseimage-docker#getting_started
+
+FROM ppc64le/ubuntu:16.04
+
+RUN apt-get update && \
+	apt-get install -y python3-minimal
+
+CMD ["/sbin/my_init"]
+
+ENV HOME /root
+
+# Uncomment these lines and comment the section underneath to allow faster
+# rebuilds when making changes to the scripts.
+# The early scripts take a long time to run but change infrequently so
+# putting them on a their own lines allow developers to take advantage of
+# Docker's layer caching. The downside is much larger images.
+# ADD /image/buildconfig /build/buildconfig
+# ADD /image/my_init /build/my_init
+# ADD /image/confd /build/confd
+# ADD /image/install.sh /build/install.sh
+# RUN /build/install.sh
+# ADD /image/system_services.sh /build/system_services.sh
+# RUN	/build/system_services.sh
+# ADD /image/cleanup.sh /build/cleanup.sh
+# RUN	/build/cleanup.sh
+
+# Comment these lines out if using the developer-focused alternative instead.
+ADD /image /build
+RUN /build/install.sh && \
+	/build/system_services.sh && \
+	/build/cleanup.sh
+
+# Copy in our custom configuration files etc. We do this last to speed up
+# builds for developer, as it's thing they're most likely to change.
+COPY node_filesystem /

--- a/build_routereflector/Makefile
+++ b/build_routereflector/Makefile
@@ -1,15 +1,34 @@
+###############################################################################
+# The build architecture is select by setting the ARCH variable.
+# For example: When building on ppc64le you could use ARCH=ppc64le make <....>.
+# When ARCH is undefined it defaults to amd64.
+ARCH?=amd64
+ifeq ($(ARCH),amd64)
+        ARCHTAG?=
+endif
+
+ifeq ($(ARCH),ppc64le)
+        ARCHTAG:=-ppc64le
+endif
+
+
 .PHONEY: clean
 
 # These variables can be overridden by setting an environment variable.
 LOCAL_IP_ENV?=$(shell ip route get 8.8.8.8 | head -1 | cut -d' ' -f8)
 
-default: clean calicorr.created
+default: clean node_filesystem/confd calicorr.created
+
+# Install Confd, for non amd64 build you must populate node_filesystem/confd befor building.
+node_filesystem/confd:
+	curl -L https://github.com/projectcalico/confd/releases/download/v0.12.1-calico0.2.0/confd \
+	 -o node_filesystem/confd
+	chmod +x node_filesystem/confd
 
 calicorr.created: $(BUILD_FILES)
-	docker build -t calico/routereflector .
+	docker build -t calico/routereflector$(ARCHTAG) -f Dockerfile$(ARCHTAG) .
 	touch calicorr.created
 
 clean:
 	-rm *.created
-	-docker rm -f calico-rr
-	-docker rmi -f calico/rr
+	-docker rmi -f calico/routereflector$(ARCHTAG)

--- a/build_routereflector/image/cleanup.sh
+++ b/build_routereflector/image/cleanup.sh
@@ -5,8 +5,11 @@ set -x
 # Remove extra packages using dpkg rather than apt-get - this prevents us from
 # deleting dependent packages that we still require.
 # - Remove any temporary packages installed in the install.sh script.
-echo "Removing extra packages"
-cat /tmp/add-apt.txt | xargs xargs dpkg -r --force-depends
+
+# On ubuntu 16:04 this trick to remove extra packags is not working as its
+# removing key parts of the python lib. 
+# echo "Removing extra packages"
+# cat /tmp/add-apt.txt | xargs xargs dpkg -r --force-depends
 
 # Remove any other junk created during installation that is not required.
 apt-get clean

--- a/build_routereflector/image/install.sh
+++ b/build_routereflector/image/install.sh
@@ -13,11 +13,11 @@ dpkg -l | grep ^ii | sed 's_  _\t_g' | cut -f 2 >/tmp/base.txt
 # Install HTTPS support for APT.
 $minimal_apt_get_install apt-transport-https ca-certificates
 
+grep -Fxvf  /tmp/base.txt <(dpkg -l | grep ^ii | sed 's_  _\t_g' | cut \
+-f 2) >/tmp/add-apt.txt1
+
 # Install add-apt-repository
 $minimal_apt_get_install software-properties-common
-
-# Install curl, needed below for manual BIRD install.
-$minimal_apt_get_install curl
 
 # Find the list of packages just installed - these can be deleted later.
 grep -Fxvf  /tmp/base.txt <(dpkg -l | grep ^ii | sed 's_  _\t_g' | cut \
@@ -28,16 +28,12 @@ LC_ALL=C.UTF-8 LANG=C.UTF-8 add-apt-repository -y ppa:cz.nic-labs/bird
 apt-get update
 
 # Install packages that should not be removed in the cleanup processing.
-# - bird and bird6
+# - bird and bird6 are both included with the bird package.
 # - packages required by felix
 # - pip (which includes various setuptools package discovery).
-$minimal_apt_get_install \
-        bird \
-        bird6
 
-# Install Confd
-curl -L https://github.com/projectcalico/confd/releases/download/v0.12.1-calico0.2.0/confd -o confd
-chmod +x confd
+$minimal_apt_get_install \
+	bird
 
 # Create the config directory for confd
 mkdir config


### PR DESCRIPTION
Signed-off-by: David Wilder <wilder@us.ibm.com>

## Description
Use "ARCH=ppc64le make"  to build the routereflector image for ppc64le.
If ARCH is un-set it defaults to amd64.