### PR TITLE
support peering with upstream ebgp node

### DIFF
--- a/build_routereflector/node_filesystem/conf.d/bird.toml
+++ b/build_routereflector/node_filesystem/conf.d/bird.toml
@@ -2,6 +2,6 @@
 src = "bird.cfg.template"
 dest = "/config/bird.cfg"
 prefix = "/calico/bgp/v1"
-keys = ["/rr_v4", "/global", "/host"]
+keys = ["/rr_v4", "/global", "/host", "/up_v4"]
 check_cmd = "bird -p -c {{.src}}"
 reload_cmd = "pkill -HUP bird || true"

--- a/build_routereflector/node_filesystem/templates/bird.cfg.template
+++ b/build_routereflector/node_filesystem/templates/bird.cfg.template
@@ -18,6 +18,30 @@ template bgp bgp_template {
   graceful restart;  # See comment in kernel section about graceful restart.
 }
 
+# Template for upstream BGP peers
+template bgp bgp_upstream_template {
+  debug off;
+  description "Connection to BGP upstream peer";
+  multihop;
+  import all;        # Import all routes, since we don't know what the upstream
+                     # topology is and therefore have to trust the ToR/RR.
+  export all;        # Export all.
+  graceful restart;  # See comment in kernel section about graceful restart.
+  next hop keep;
+}
+
+# ------------- RR-to-Upstream -------------
+{{if ls "/up_v4"}}
+{{range gets "/up_v4/*"}}{{$data := json .Value}}{{$up_ip := $data.ip}}{{$up_as := $data.as_num}}
+{{$nums := split $up_ip "."}}{{$id := join $nums "_"}}
+# For UP {{$up_ip}}
+{{if ne "" $up_ip}}protocol bgp Upstream_{{$id}} from bgp_upstream_template {
+  local as {{getv "/global/as_num"}};
+  neighbor {{$up_ip}} as {{$up_as}};
+}{{end}}{{end}}
+{{end}}
+
+
 {{$our_rr_key := printf "/rr_v4/%s" (getenv "IP")}}
 {{if ls $our_rr_key}}{{$our_rr_data := json (getv $our_rr_key)}}
 # ------------- RR-to-RR full mesh -------------

--- a/build_routereflector/node_filesystem/templates/bird6.cfg.template
+++ b/build_routereflector/node_filesystem/templates/bird6.cfg.template
@@ -20,6 +20,30 @@ template bgp bgp_template {
   graceful restart;  # See comment in kernel section about graceful restart.
 }
 
+# Template for upstream BGP peers
+template bgp bgp_upstream_template {
+  debug off;
+  description "Connection to BGP upstream peer";
+  multihop;
+  import all;        # Import all routes, since we don't know what the upstream
+                     # topology is and therefore have to trust the ToR/RR.
+  export all;        # Export all.
+  source address {{getenv "IP6"}};  # The local address we use for the TCP connection
+  graceful restart;  # See comment in kernel section about graceful restart.
+  next hop keep;
+}
+
+
+# ------------- RR-to-Upstream -------------
+{{if ls "/up_v6"}}
+{{range gets "/up_v6/*"}}{{$data := json .Value}}{{$up_ip := $data.ip}}{{$up_as := $data.as_num}}
+{{$nums := split $up_ip ":"}}{{$id := join $nums "_"}}
+# For UP {{$up_ip}}
+{{if ne "" $up_ip}}protocol bgp Upstream_{{$id}} from bgp_upstream_template {
+  local as {{getv "/global/as_num"}};
+  neighbor {{$up_ip}} as {{$up_as}};
+}{{end}}{{end}}
+{{end}}
 
 {{$our_rr_key := printf "/rr_v6/%s" (getenv "IP6")}}
 {{if ls $our_rr_key}}{{$our_rr_data := json (getv $our_rr_key)}}


### PR DESCRIPTION
Hello, sorry for the following wall of text :smile: 

I'm creating this PR to add the ability to peer with external BGP nodes using the routereflector container. We are planning to build Kubernetes clusters in our environments in which all nodes will peer with two route reflectors. In turn, we're looking to allow those route reflectors to peer with and upstream eBGP node and share routes up to it. Here's a very ugly diagram of what we're working towards:

![image uploaded from ios](https://user-images.githubusercontent.com/1529818/32675694-ccf6b4d0-c625-11e7-84c1-da0a0387e818.jpg)

This PR adds some extra bits into the confd files used to lay down bird configs in the routereflector containers. These extra bits will search for two new directories in etcd, `up_v4` or `up_v6`, and if found, will use the values pushed into that directory to template out the upstream node peering. In regards to the etcd keys, we tried to keep pretty close to what was already present with `rr_v4`.  Here is an example of the layout we are proposing:

```bash
$ etcdctl --endpoints https://127.0.0.1:2379 get /calico/bgp/v1/up_v4/10.100.48.173

{ "ip": "10.100.48.173", "as_num": "64513" }
```
To test all of this, we did the following:
- Pushed the data above into etcd.
- Installed bird on 10.100.48.173 and configured it with its own ASN (64513 vs. 64512 for our other nodes). We also told it to expect the routereflector node to peer:
```bash
...
protocol bgp Node_10_100_48_170 from bgp_template {
  neighbor 10.100.48.170 as 64512;
}
...
```

- Launched a newly created routereflector image with the changes in the PR.
- Verified the config generated by confd:
```bash
...
# ------------- RR-to-Upstream -------------
# For UP 10.100.48.173
protocol bgp Upstream_10_100_48_173 from bgp_template {
  local as 64512;
  neighbor 10.100.48.173 as 64513;
}
...
```
- Saw that the routes we had defined in our Kubernetes cluster (10.233.*.* addresses) were present when showing routes in the upstream bird install:
```bash
bird> show route all
10.233.97.192/26   unreachable [Node_10_100_48_170 17:04:39 from 10.100.48.170] * (100/-) [AS64512i]
    Type: BGP unicast univ
    BGP.origin: IGP
    BGP.as_path: 64512
    BGP.next_hop: 10.100.48.170
    BGP.local_pref: 100
10.233.76.64/26    unreachable [Node_10_100_48_170 17:04:39 from 10.100.48.170] * (100/-) [AS64512i]
    Type: BGP unicast univ
    BGP.origin: IGP
    BGP.as_path: 64512
    BGP.next_hop: 10.100.48.170
    BGP.local_pref: 100
10.233.90.0/26     unreachable [Node_10_100_48_170 17:04:39 from 10.100.48.170] * (100/-) [AS64512i]
    Type: BGP unicast univ
    BGP.origin: IGP
    BGP.as_path: 64512
    BGP.next_hop: 10.100.48.170
    BGP.local_pref: 100
10.233.87.128/26   unreachable [Node_10_100_48_170 17:04:39 from 10.100.48.170] * (100/-) [AS64512i]
    Type: BGP unicast univ
    BGP.origin: IGP
    BGP.as_path: 64512
    BGP.next_hop: 10.100.48.170
    BGP.local_pref: 100
```

/cc @bradbeam