### PR TITLE
Check interface index when scanning routes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,5 @@
 /configure
 /bird.conf
 /bird.log
+dist
+configure.lineno


### PR DESCRIPTION
## Description
Tentative fix for https://github.com/projectcalico/calico/issues/1584

Symptoms in the calico issue suggest that old tunl routes are not being cleaned up during a route scan.  I'm wondering if we should be checking iface index alongside the gway.

The function `krt_same_dest` is only called from `krt_got_route` - this latter function deals with processing of scanned routes.

## Todos
- [ ] Unit tests (full coverage)
- [ ] Integration tests (delete as appropriate) In plan/Not needed/Done
- [ ] Documentation
- [ ] Backport