### PR TITLE
Update BIRD version string

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,5 +1,6 @@
 # Release Process
 
+-  Edit `BIRD_VERSION` in `sysdep/config.h`
 -  Create a new branch for your release (e.g. `v0.2.2-branch`)
 -  Wait for CircleCI to build the branch.
 -  Cut a new release (create a tag with the correct version name), copy across

--- a/sysdep/config.h
+++ b/sysdep/config.h
@@ -7,7 +7,7 @@
 #define _BIRD_CONFIG_H_
 
 /* BIRD version */
-#define BIRD_VERSION "1.6.3"
+#define BIRD_VERSION "v0.3.2+birdv1.6.3"
 
 /* Include parameters determined by configure script */
 #include "sysdep/autoconf.h"


### PR DESCRIPTION
## Description
bird version string still indicates the original bird version

updated to be the next Calico release of bird.  Original version added as metadata.

## Todos
- [ ] Unit tests (full coverage)
- [ ] Integration tests (delete as appropriate) In plan/Not needed/Done
- [ ] Documentation
- [ ] Backport
