### PR TITLE
Add s390x Dockerfile

### DIFF
--- a/Dockerfile-s390x
+++ b/Dockerfile-s390x
@@ -1,0 +1,6 @@
+FROM s390x/alpine:latest
+
+RUN apk update
+RUN apk add alpine-sdk linux-headers autoconf flex bison ncurses-dev readline-dev 
+
+WORKDIR /code

--- a/build.sh
+++ b/build.sh
@@ -37,6 +37,12 @@ case $ARCH in
 		TARGETARCH=
 		DOCKERFILE=Dockerfile
 		;;
+	s390x)
+	  	ARCH=s390x
+	  	BUILDARCH=s390x
+		TARGETARCH=
+		DOCKERFILE=Dockerfile-s390x
+		;;
 	*)
 		echo "Unknown architecture $ARCH."
 		exit 1


### PR DESCRIPTION
Signed-off-by: jose-bigio <jose.bigio@docker.com>

## Description
In order to have `s390x` builds for `calico/node` there needs to be `s390x` builds for bird.




Can I build from https://github.com/projectcalico/bird/blob/v0.3.2/build.sh ?

