### PR TITLE
Replace for loop with multiple make targets

### DIFF
--- a/Makefile.calico
+++ b/Makefile.calico
@@ -38,6 +38,9 @@ CALICO_GIT_VER := $(shell git describe --tags --dirty --always)
 
 # because we are not using the default Makefile
 where-am-i = $(word $(words $(MAKEFILE_LIST)),$(MAKEFILE_LIST))
+# so we can use names in targets
+escapefs = $(subst :,---,$(subst /,___,$(1)))
+unescapefs = $(subst ---,:,$(subst ___,/,$(1)))
 
 # Variables for controlling image tagging and pushing.
 DOCKER_REPOS=calico quay.io/calico
@@ -70,11 +73,14 @@ sub-image-%:
 	$(MYMAKE) image ARCH=$*
 
 ## push one arch
-push: imagetag
-	for r in $(DOCKER_REPOS); do docker push $$r/$(CONTAINER_BASENAME):$(IMAGETAG)-$(ARCH); done
+push: imagetag $(addprefix sub-single-push-,$(call escapefs,$(DOCKER_REPOS)))
+
+sub-single-push-%:
+	docker push $(call unescapefs,$*/$(CONTAINER_BASENAME):$(IMAGETAG)-$(ARCH))
 ifeq ($(ARCH),amd64)
-	for r in $(DOCKER_REPOS); do docker push $$r/$(CONTAINER_BASENAME):$(IMAGETAG); done
+	docker push $(call unescapefs,$*/$(CONTAINER_BASENAME):$(IMAGETAG))
 endif
+
 
 ## push all supported arches
 push-all: imagetag $(addprefix sub-push-,$(VALIDARCHES))
@@ -82,11 +88,15 @@ sub-push-%:
 	$(MYMAKE) push ARCH=$* IMAGETAG=$(IMAGETAG)
 
 ## tag images of one arch
-tag-images: imagetag
-	for r in $(DOCKER_REPOS); do docker tag $(CONTAINER_NAME):latest-$(ARCH) $$r/$(CONTAINER_BASENAME):$(IMAGETAG)-$(ARCH); done
+tag-images: imagetag $(addprefix sub-single-tag-images-,$(call escapefs,$(DOCKER_REPOS)))
+
+sub-single-tag-images-%:
+	docker tag $(CONTAINER_NAME):latest-$(ARCH) $(call unescapefs,$*/$(CONTAINER_BASENAME):$(IMAGETAG)-$(ARCH))
 ifeq ($(ARCH),amd64)
-	for r in $(DOCKER_REPOS); do docker tag $(CONTAINER_NAME):latest-$(ARCH) $$r/$(CONTAINER_BASENAME):$(IMAGETAG); done
+	docker tag $(CONTAINER_NAME):latest-$(ARCH) $(call unescapefs,$*/$(CONTAINER_BASENAME):$(IMAGETAG))
 endif
+
+
 
 ## tag images of all archs
 tag-images-all: imagetag $(addprefix sub-tag-images-,$(VALIDARCHES))


### PR DESCRIPTION
## Description
A few sentences describing the overall goals of the pull request's commits. 
Please include 
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR

The `for` loop used in the makefile in the `push` and `tag-images` target works, but if any one of the loop fails, it does _not_ error out. If the last one works, but the first does not, it looks like the target succeeded when it did not.

This replaces the `for` loop with make targets, so that it works.

It needs to `escapefs` and `unescapefs` because you cannot have `/` or `:` (invalid filename chars) in the makefile stem.

cc @fasaxc 

## Todos
- [ ] Unit tests (full coverage)
- [ ] Integration tests (delete as appropriate) In plan/Not needed/Done
- [ ] Documentation
- [ ] Backport
