### PR TITLE
Fix error in build

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -36,7 +36,7 @@ esac
 # get the correct TARGETARCH
 case $ARCH in
 	all)
-		TARGETARCH="amd64 aarch64 powerpc64le"
+		TARGETARCH="amd64 aarch64 powerpc64le s390x"
 		;;
 	amd64|x86_64)
 		TARGETARCH=$ARCH
@@ -58,9 +58,9 @@ esac
 # get the right dockerfile
 DOCKERFILE=Dockerfile
 IMAGE=birdbuild-$ARCH
-if [ $BUILDARCH != $TARGETARCH ]; then
+if [ "$BUILDARCH" != "$TARGETARCH" ]; then
 	DOCKERFILE=Dockerfile-cross
-	IMAGE=birdbuild-$ARCH-cross
+	IMAGE=birdbuild-$BUILDARCH-cross
 fi
 
 


### PR DESCRIPTION
## Description
Fixes several things:

* Running `ARCH=all build.sh` (which is called by `make build-all`) had an error in its `sh` test, which in turn would cause it to use the wrong `Dockerfile` and builds would fail. This fixes it.
* The cross-builder image was tagged by the _target_ arch rather than the _builder_ arch, which made no sense and led to a proliferation of tags
* `build-all` did not build `s390x`, even though that build actually does work, and the image is just a `scratch` image without `qemu` emulation, so we can build it, and `make image` does build it. This ensures it does.


