### PR TITLE
Build entirely in separate dir per arch to avoid .o conflicts

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -65,6 +65,7 @@ fi
 
 
 DIST=dist/
+OBJ=obj/
 
 docker build -t $IMAGE -f builder-images/$DOCKERFILE .
 mkdir -p $DIST
@@ -72,4 +73,4 @@ mkdir -p $DIST
 #    ARCH = architecture on which I am running
 #    TARGETARCH = architecture(s) for which I am building, if different than ARCH (blank if the same) 
 #    DIST = root directory in which to put binaries, structured as $DIST/$TARGETARCH
-docker run --rm --name bird-build -e ARCH=$BUILDARCH -e TARGETARCH="$TARGETARCH" -e DIST=$DIST -v `pwd`:/code $IMAGE ./create_binaries.sh
+docker run --rm --name bird-build -e ARCH=$BUILDARCH -e TARGETARCH="$TARGETARCH" -e DIST=$DIST -e OBJ=$OBJ -v `pwd`:/code $IMAGE ./create_binaries.sh


### PR DESCRIPTION
## Description
When running builds for multiple architectures, sometimes the lingering `*.o` files from a different arch do not get removed, making it impossible to link a binary for the currently targeted arch.

This PR moves all of the builds into `obj/<arch>/`, thus eliminating any possible conflicts.

cc @fasaxc 