### PR TITLE
Build for 32-bit arm v7

### DIFF
--- a/Makefile.calico
+++ b/Makefile.calico
@@ -5,6 +5,9 @@ BUILDARCH ?= $(shell uname -m)
 BUILDOS ?= $(shell uname -s | tr A-Z a-z)
 
 # canonicalized names for host architecture
+ifeq ($(BUILDARCH),armv7l)
+        BUILDARCH=armv7
+endif
 ifeq ($(BUILDARCH),aarch64)
         BUILDARCH=arm64
 endif
@@ -16,6 +19,9 @@ endif
 ARCH ?= $(BUILDARCH)
 
 # canonicalized names for target architecture
+ifeq ($(ARCH),armv7l)
+        override ARCH=armv7
+endif
 ifeq ($(ARCH),aarch64)
         override ARCH=arm64
 endif

--- a/build.sh
+++ b/build.sh
@@ -18,6 +18,9 @@ case $BUILDARCH in
 	amd64|x86_64)
 		BUILDARCH=amd64
 		;;
+	armv7l)
+		BUILDARCH=armv7
+		;;
 	arm64|aarch64)
 		BUILDARCH=aarch64
 		;;
@@ -40,6 +43,9 @@ case $ARCH in
 		;;
 	amd64|x86_64)
 		TARGETARCH=$ARCH
+		;;
+	armv7l)
+		TARGETARCH=armv7
 		;;
 	arm64|aarch64)
 		TARGETARCH=aarch64

--- a/builder-images/Dockerfile-cross
+++ b/builder-images/Dockerfile-cross
@@ -1,12 +1,14 @@
 FROM gcc:latest
 MAINTAINER Tom Denham <tom@projectcalico.org>
 
+RUN dpkg --add-architecture armhf
 RUN dpkg --add-architecture arm64
 RUN dpkg --add-architecture ppc64el
 RUN dpkg --add-architecture s390x
 RUN apt update
 RUN apt install -y autoconf flex bison \
 	libncurses-dev libreadline-dev \
+	binutils-arm-linux-gnueabihf gcc-arm-linux-gnueabihf libncurses-dev:armhf libreadline-dev:armhf \
 	binutils-aarch64-linux-gnu gcc-aarch64-linux-gnu libncurses-dev:arm64 libreadline-dev:arm64 \
 	binutils-powerpc64le-linux-gnu gcc-powerpc64le-linux-gnu libncurses-dev:ppc64el libreadline-dev:ppc64el \
 	binutils-s390x-linux-gnu gcc-s390x-linux-gnu libncurses-dev:s390x libreadline-dev:s390x

--- a/docker-image/Dockerfile.armv7
+++ b/docker-image/Dockerfile.armv7
@@ -1,0 +1,1 @@
+Dockerfile


### PR DESCRIPTION
## Description

Add support for the 32-bit arm v7 architecture for both native and cross builds.

This change is the second step to https://github.com/projectcalico/go-build/pull/100 in making all of calico buildable for armv7. It is currently in experimentation state since I am not familiar with the design decisions impacting overall calico build processes.

## Todos
- [ ] generalize cross build steps
- [ ] Unit tests (full coverage)
- [ ] Integration tests: planned
- [ ] Documentation
- [ ] Backport --> Not needed
