### PR TITLE
optimization debian package manager tweaks

### DIFF
--- a/builder-images/Dockerfile-cross
+++ b/builder-images/Dockerfile-cross
@@ -5,7 +5,7 @@ RUN dpkg --add-architecture arm64
 RUN dpkg --add-architecture ppc64el
 RUN dpkg --add-architecture s390x
 RUN apt update
-RUN apt install -y autoconf flex bison \
+RUN apt-get --no-install-recommends install -y autoconf flex bison \
 	libncurses-dev libreadline-dev \
 	binutils-aarch64-linux-gnu gcc-aarch64-linux-gnu libncurses-dev:arm64 libreadline-dev:arm64 \
 	binutils-powerpc64le-linux-gnu gcc-powerpc64le-linux-gnu libncurses-dev:ppc64el libreadline-dev:ppc64el \

--- a/misc/docker/debian-7-amd64/Dockerfile
+++ b/misc/docker/debian-7-amd64/Dockerfile
@@ -3,7 +3,7 @@ ENV DEBIAN_FRONTEND noninteractive
 RUN sed -i 's/deb.debian.org/ftp.cz.debian.org/' /etc/apt/sources.list
 RUN apt-get -y update
 RUN apt-get -y upgrade
-RUN apt-get -y install \
+RUN apt-get --no-install-recommends install -y \
 	autoconf \
 	build-essential \
 	flex \

--- a/misc/docker/debian-7-i386/Dockerfile
+++ b/misc/docker/debian-7-i386/Dockerfile
@@ -3,7 +3,7 @@ ENV DEBIAN_FRONTEND noninteractive
 RUN sed -i 's/deb.debian.org/ftp.cz.debian.org/' /etc/apt/sources.list
 RUN apt-get -y update
 RUN apt-get -y upgrade
-RUN apt-get -y install \
+RUN apt-get --no-install-recommends install -y \
 	autoconf \
 	build-essential \
 	flex \

--- a/misc/docker/debian-8-amd64/Dockerfile
+++ b/misc/docker/debian-8-amd64/Dockerfile
@@ -3,7 +3,7 @@ ENV DEBIAN_FRONTEND noninteractive
 RUN sed -i 's/deb.debian.org/ftp.cz.debian.org/' /etc/apt/sources.list
 RUN apt-get -y update
 RUN apt-get -y upgrade
-RUN apt-get -y install \
+RUN apt-get --no-install-recommends install -y \
 	autoconf \
 	build-essential \
 	flex \

--- a/misc/docker/debian-8-i386/Dockerfile
+++ b/misc/docker/debian-8-i386/Dockerfile
@@ -3,7 +3,7 @@ ENV DEBIAN_FRONTEND noninteractive
 RUN sed -i 's/deb.debian.org/ftp.cz.debian.org/' /etc/apt/sources.list
 RUN apt-get -y update
 RUN apt-get -y upgrade
-RUN apt-get -y install \
+RUN apt-get --no-install-recommends install -y \
 	autoconf \
 	build-essential \
 	flex \

--- a/misc/docker/debian-9-amd64/Dockerfile
+++ b/misc/docker/debian-9-amd64/Dockerfile
@@ -3,7 +3,7 @@ ENV DEBIAN_FRONTEND noninteractive
 RUN sed -i 's/deb.debian.org/ftp.cz.debian.org/' /etc/apt/sources.list
 RUN apt-get -y update
 RUN apt-get -y upgrade
-RUN apt-get -y install \
+RUN apt-get --no-install-recommends install -y \
 	autoconf \
 	build-essential \
 	flex \

--- a/misc/docker/debian-9-i386/Dockerfile
+++ b/misc/docker/debian-9-i386/Dockerfile
@@ -3,7 +3,7 @@ ENV DEBIAN_FRONTEND noninteractive
 RUN sed -i 's/deb.debian.org/ftp.cz.debian.org/' /etc/apt/sources.list
 RUN apt-get -y update
 RUN apt-get -y upgrade
-RUN apt-get -y install \
+RUN apt-get --no-install-recommends install -y \
 	autoconf \
 	build-essential \
 	flex \

--- a/misc/docker/debian-testing-amd64/Dockerfile
+++ b/misc/docker/debian-testing-amd64/Dockerfile
@@ -3,7 +3,7 @@ ENV DEBIAN_FRONTEND noninteractive
 RUN sed -i 's/deb.debian.org/ftp.cz.debian.org/' /etc/apt/sources.list
 RUN apt-get -y update
 RUN apt-get -y upgrade
-RUN apt-get -y install \
+RUN apt-get --no-install-recommends install -y \
 	autoconf \
 	build-essential \
 	flex \

--- a/misc/docker/debian-testing-i386/Dockerfile
+++ b/misc/docker/debian-testing-i386/Dockerfile
@@ -3,7 +3,7 @@ ENV DEBIAN_FRONTEND noninteractive
 RUN sed -i 's/deb.debian.org/ftp.cz.debian.org/' /etc/apt/sources.list
 RUN apt-get -y update
 RUN apt-get -y upgrade
-RUN apt-get -y install \
+RUN apt-get --no-install-recommends install -y \
 	autoconf \
 	build-essential \
 	flex \

--- a/misc/docker/ubuntu-14.04-amd64/Dockerfile
+++ b/misc/docker/ubuntu-14.04-amd64/Dockerfile
@@ -3,7 +3,7 @@ ENV DEBIAN_FRONTEND noninteractive
 RUN sed -i 's/deb.debian.org/ftp.cz.debian.org/' /etc/apt/sources.list
 RUN apt-get -y update
 RUN apt-get -y upgrade
-RUN apt-get -y install \
+RUN apt-get --no-install-recommends install -y \
 	autoconf \
 	build-essential \
 	flex \

--- a/misc/docker/ubuntu-16.04-amd64/Dockerfile
+++ b/misc/docker/ubuntu-16.04-amd64/Dockerfile
@@ -3,7 +3,7 @@ ENV DEBIAN_FRONTEND noninteractive
 RUN sed -i 's/deb.debian.org/ftp.cz.debian.org/' /etc/apt/sources.list
 RUN apt-get -y update
 RUN apt-get -y upgrade
-RUN apt-get -y install \
+RUN apt-get --no-install-recommends install -y \
 	autoconf \
 	build-essential \
 	flex \


### PR DESCRIPTION
By default, Ubuntu or Debian based "apt" or "apt-get" system installs recommended but not suggested packages .

By passing "--no-install-recommends" option, the user lets apt-get know not to consider recommended packages as a dependency to install.

This results in smaller downloads and installation of packages .

Refer to blog at [Ubuntu Blog](https://ubuntu.com/blog/we-reduced-our-docker-images-by-60-with-no-install-recommends) .

Signed-off-by: Pratik Raj <rajpratik71@gmail.com>

## Description
A few sentences describing the overall goals of the pull request's commits. 
Please include 
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR

## Todos
- [ ] Unit tests (full coverage)
- [ ] Integration tests (delete as appropriate) In plan/Not needed/Done
- [ ] Documentation
- [ ] Backport
