### PR TITLE
Add s390x support

### DIFF
--- a/create_binaries.sh
+++ b/create_binaries.sh
@@ -16,6 +16,7 @@ for i in $TARGETARCH; do
 	[ "$dirarch" = "aarch64" ] && dirarch=arm64
 	[ "$dirarch" = "ppc64el" ] && dirarch=ppc64le
 	[ "$dirarch" = "powerpc64le" ] && dirarch=ppc64le
+        [ "$dirarch" = "s390x" ] && dirarch=s390x
 
 	# where we place our output binaries
 	distarch=$DIST/$dirarch

--- a/create_binaries.sh
+++ b/create_binaries.sh
@@ -16,7 +16,7 @@ for i in $TARGETARCH; do
 	[ "$dirarch" = "aarch64" ] && dirarch=arm64
 	[ "$dirarch" = "ppc64el" ] && dirarch=ppc64le
 	[ "$dirarch" = "powerpc64le" ] && dirarch=ppc64le
-        [ "$dirarch" = "s390x" ] && dirarch=s390x
+	[ "$dirarch" = "s390x" ] && dirarch=s390x
 
 	# where we place our output binaries
 	distarch=$DIST/$dirarch


### PR DESCRIPTION
Signed-off-by: Nirman Narang <narang@us.ibm.com>

## Description
s390x support does not exist in create_binaries.sh script. Hence adding the same.