### PR TITLE
Add -fcommon to CFLAGS

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -136,6 +136,8 @@ if test -z "$GCC" ; then
   AC_MSG_ERROR([This program requires the GNU C Compiler.])
 fi
 
+CFLAGS="$CFLAGS -fcommon"
+
 if test "$enable_pthreads" != no ; then
   BIRD_CHECK_PTHREADS
 


### PR DESCRIPTION
To fix this problem, which we've been seeing since gcc:latest became
GCC 10:

    LD -r -o all.o cf-parse.tab.o cf-lex.o conf.o
    /usr/bin/ld: cf-lex.o:/code/obj/amd64/conf/../lib/krt.h:115: multiple definition of `kif_proto'; cf-parse.tab.o:/code/obj/amd64/conf/../lib/krt.h:115: first defined here
    collect2: error: ld returned 1 exit status

The GCC 10 release notes say:

    GCC now defaults to -fno-common. As a result, global variable
    accesses are more efficient on various targets. In C, global
    variables with multiple tentative definitions now result in linker
    errors. With -fcommon such definitions are silently merged during
    linking.

(https://gcc.gnu.org/gcc-10/changes.html)

## Description
A few sentences describing the overall goals of the pull request's commits. 
Please include 
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR

## Todos
- [ ] Unit tests (full coverage)
- [ ] Integration tests (delete as appropriate) In plan/Not needed/Done
- [ ] Documentation
- [ ] Backport
