### PR TITLE
Ensure that /var/run/calico exists

### DIFF
--- a/dist/amd64/birdy/bird-wrapper.sh
+++ b/dist/amd64/birdy/bird-wrapper.sh
@@ -11,6 +11,10 @@ fi
 sed -i "s/BIRD_ROUTERID/${ROUTER_ID}/g" /etc/bird.conf
 sed -i "s/BIRD_ROUTERID/${ROUTER_ID}/g" /etc/bird6.conf
 
+# Ensure that /var/run/calico (which is where the control socket file
+# will be) exists.
+mkdir -p /var/run/calico
+
 # Start bird and bird6 (which will both daemonize)
 bird
 bird6


### PR DESCRIPTION
This is needed when the BIRD image is used independently of
calico-node, as it is in the node STs (to model an external node) and
the dual ToR STs (to model the ToRs).

## Description
A few sentences describing the overall goals of the pull request's commits. 
Please include 
- the type of fix - (e.g. bug fix, new feature, documentation)
- some details on _why_ this PR should be merged
- the details of the testing you've done on it (both manual and automated)
- which components are affected by this PR

## Todos
- [ ] Unit tests (full coverage)
- [ ] Integration tests (delete as appropriate) In plan/Not needed/Done
- [ ] Documentation
- [ ] Backport
