### PR TITLE
image-all should be a dependency of cd

### DIFF
--- a/Makefile.calico
+++ b/Makefile.calico
@@ -117,7 +117,7 @@ endif
 ci: image-all test-protocol-support
 
 ## Deploys images to registry
-cd:
+cd: image-all
 ifndef CONFIRM
 	$(error CONFIRM is undefined - run using make <target> CONFIRM=true)
 endif


### PR DESCRIPTION
## Description
In the Makefile, `image-all` should be a dependency of `cd` since if you checkout this repo fresh and run `make cd`, it will fail (which is what's happening in our semaphore v2 pipeline).

## Todos
- [ ] Unit tests (full coverage)
- [ ] Integration tests Not needed
- [ ] Documentation
- [ ] Backport
