### PR TITLE
Treat 240.0.0.0/8 IPv4 range like RFC 1918 ranges

### DIFF
--- a/lib/ip.c
+++ b/lib/ip.c
@@ -90,6 +90,7 @@ ip4_classify(ip4_addr ad)
     if (b == 0x7f)
       return IADDR_HOST | SCOPE_HOST;
     else if ((b == 0x0a) ||
+	     (b == 0xf0) ||
 	     ((a & 0xffff0000) == 0xc0a80000) ||
 	     ((a & 0xfff00000) == 0xac100000))
       return IADDR_HOST | SCOPE_SITE;


### PR DESCRIPTION
Note, this is contrary to current standards, but has been requested by
one of our customers.
