### PR TITLE
Match the broadcast address before the 240.0.0.0/4 CIDR

### DIFF
--- a/lib/ip.c
+++ b/lib/ip.c
@@ -97,14 +97,14 @@ ip4_classify(ip4_addr ad)
       return IADDR_HOST | SCOPE_UNIVERSE;
   }
 
+  if (a == 0xffffffff)
+    return IADDR_BROADCAST | SCOPE_LINK;
+
   if (b >= 0xf0)
       return IADDR_HOST | SCOPE_SITE;
 
   if (b >= 0xe0 && b <= 0xef)
     return IADDR_MULTICAST | SCOPE_UNIVERSE;
-
-  if (a == 0xffffffff)
-    return IADDR_BROADCAST | SCOPE_LINK;
 
   return IADDR_INVALID;
 }


### PR DESCRIPTION
## Description
The check for the 240.0.0.0/4 CIDR was also matching the broadcast address 255.255.255.255
Moved the broadcast check above the 240.0.0.0/4 check

## Release Note

<!-- Writing a release note:
- By default, no release note action is required.
- If you're unsure whether or not your PR needs a note, ask your reviewer for guidance.
- If this PR requires a release note, update the block below to include a concise note describing
  the change and any important impacts this PR may have.
-->

```release-note
Fix a bug where the check for treating the 240/4 CIDR like RFC 1918 ranges caught the broadcast address 255.255.255.255
```