### PR TITLE
Unix: Fix signals synchronization

### DIFF
--- a/sysdep/unix/io.c
+++ b/sysdep/unix/io.c
@@ -30,6 +30,7 @@
 #include <netinet/tcp.h>
 #include <netinet/udp.h>
 #include <netinet/icmp6.h>
+#include <stdatomic.h>
 
 #include "nest/bird.h"
 #include "lib/lists.h"
@@ -2178,18 +2179,16 @@ io_loop(void)
        * and entering poll(), it gets caught on the next timer tick.
        */
 
-      if (async_config_flag)
+      if (atomic_exchange(&async_config_flag, 0))
 	{
 	  io_log_event(async_config, NULL);
 	  async_config();
-	  async_config_flag = 0;
 	  continue;
 	}
-      if (async_dump_flag)
+      if (atomic_exchange(&async_dump_flag, 0))
 	{
 	  io_log_event(async_dump, NULL);
 	  async_dump();
-	  async_dump_flag = 0;
 	  continue;
 	}
       if (async_shutdown_flag)

--- a/sysdep/unix/main.c
+++ b/sysdep/unix/main.c
@@ -21,6 +21,7 @@
 #include <grp.h>
 #include <sys/stat.h>
 #include <libgen.h>
+#include <stdatomic.h>
 
 #include "nest/bird.h"
 #include "lib/lists.h"
@@ -578,14 +579,14 @@ static void
 handle_sighup(int sig UNUSED)
 {
   DBG("Caught SIGHUP...\n");
-  async_config_flag = 1;
+  atomic_store(&async_config_flag, 1);
 }
 
 static void
 handle_sigusr(int sig UNUSED)
 {
   DBG("Caught SIGUSR...\n");
-  async_dump_flag = 1;
+  atomic_store(&async_dump_flag, 1);
 }
 
 static void


### PR DESCRIPTION
## Description
Event loop (`io_loop`) must ensure that there is no new signal received between signal processing and flag reset to `0`. This PR aims to fix the current behavior of the signal management to ensure that there is no missed signals.

We experienced some routing issue on our Kubernetes cluster since we frequently deploy a lot of new pods (`cronjobs`). After checking bird's logs, we noticed that sometimes 2 `SIGHUP` were sent with few ms delay between them and only the first one was processed. This led to route inconsistency on nodes.

Logs before this fix (2 `SIGHUP`, last one is never processed and routes are never removed):
```
2022-03-28 17:31:52.785 [INFO][74] confd/resource.go 278: Target config /etc/calico/confd/config/bird_aggr.cfg has been updated due to change in key: /calico/ipam/v2/host/worker-028/ipv4/block
bird: Reconfiguration requested by SIGHUP
bird: Reconfiguring
bird: device1: Reconfigured
bird: direct1: Reconfigured
bird: Mesh_10_1_100_31: Reconfigured
[...] # a lot of "Mesh_XXXX: Reconfigured" here
2022-03-28 17:31:52.791 [INFO][74] confd/resource.go 278: Target config /etc/calico/confd/config/bird_aggr.cfg has been updated due to change in key: /calico/ipam/v2/host/worker-028/ipv4/block
[...] # a lot of "Mesh_XXXX: Reconfigured" here
bird: Mesh_10_1_101_214: Reconfigured
bird: Reconfigured
```

Logs after this fix (2 `SIGHUP`, both are processed):
```
2022-03-29 14:57:18.427 [INFO][74] confd/resource.go 278: Target config /etc/calico/confd/config/bird_aggr.cfg has been updated due to change in key: /calico/ipam/v2/host/worker-028/ipv4/block
bird: Reconfiguration requested by SIGHUP
bird: Reconfiguring
bird: device1: Reconfigured
bird: direct1: Reconfigured
bird: Mesh_10_1_100_31: Reconfigured
[...] # a lot of "Mesh_XXXX: Reconfigured" here
2022-03-29 14:57:18.434 [INFO][74] confd/resource.go 278: Target config /etc/calico/confd/config/bird_aggr.cfg has been updated due to change in key: /calico/ipam/v2/host/worker-028/ipv4/block
[...] # a lot of "Mesh_XXXX: Reconfigured" here
bird: Mesh_10_1_101_214: Reconfigured
bird: Reconfigured
bird: Reconfiguration requested by SIGHUP
bird: Reconfiguring
bird: device1: Reconfigured
bird: direct1: Reconfigured
bird: Mesh_10_1_100_31: Reconfigured
[...] # a lot of "Mesh_XXXX: Reconfigured" here
bird: Mesh_10_1_101_214: Reconfigured
bird: Reconfigured
```

```release-note
Fix race condition in BIRD that could potentially cause missed config updates
```