### PR TITLE
[proto/device] Ignore addr updates on DOWN ifcs

### DIFF
--- a/sysdep/linux/netlink.c
+++ b/sysdep/linux/netlink.c
@@ -745,6 +745,12 @@ nl_parse_addr(struct nlmsghdr *h, int scan)
       return;
     }
 
+  if (!(ifi->flags & IF_ADMIN_UP)) /* Ignore addresses for DOWN interfaces. */
+    {
+      log(L_DEBUG "KIF: Ignore %s that is not UP", ifi->name);
+      return;
+    }
+
   bzero(&ifa, sizeof(ifa));
   ifa.iface = ifi;
   if (ifa_flags & IFA_F_SECONDARY)


### PR DESCRIPTION

## Description
Ignores netlink addr updates for interfaces that *do not* have UP admin state. Improves performance for kube-ipvs* interfaces with large number of addresses. Could be one of the reasons behind https://github.com/projectcalico/bird/issues/95 when kube-proxy IPVS mode is used:

<img width="835" alt="Screen Shot 2022-11-14 at 4 46 26 PM" src="https://user-images.githubusercontent.com/767232/204403101-cc16baf4-ed42-4cfe-9f21-fbb4e6c9a9d9.png">
