### PR TITLE
Add dind (docker-in-docker) + bird container image

### DIFF
--- a/Makefile.calico
+++ b/Makefile.calico
@@ -84,7 +84,7 @@ sub-image-%:
 .PHONY: dind-image
 dind-image: $(DIND_CONTAINER_NAME)
 $(DIND_CONTAINER_NAME): $(BINARIES)
-	docker build -t $(DIND_CONTAINER_NAME):latest-$(ARCH) -f dind-image/Dockerfile.$(ARCH) dist/$(ARCH)
+	docker build -t $@:latest-$(ARCH) -f dind-image/Dockerfile.$(ARCH) dist/$(ARCH)
 
 ## push one arch
 push: imagetag $(addprefix sub-single-push-,$(call escapefs,$(DOCKER_REPOS)))

--- a/Makefile.calico
+++ b/Makefile.calico
@@ -91,8 +91,10 @@ push: imagetag $(addprefix sub-single-push-,$(call escapefs,$(DOCKER_REPOS)))
 
 sub-single-push-%:
 	docker push $(call unescapefs,$*/$(CONTAINER_BASENAME):$(IMAGETAG)-$(ARCH))
+	docker push $(call unescapefs,$*/$(DIND_CONTAINER_BASENAME):$(IMAGETAG)-$(ARCH))
 ifeq ($(ARCH),amd64)
 	docker push $(call unescapefs,$*/$(CONTAINER_BASENAME):$(IMAGETAG))
+	docker push $(call unescapefs,$*/$(DIND_CONTAINER_BASENAME):$(IMAGETAG))
 endif
 
 
@@ -106,8 +108,10 @@ tag-images: imagetag $(addprefix sub-single-tag-images-,$(call escapefs,$(DOCKER
 
 sub-single-tag-images-%:
 	docker tag $(CONTAINER_NAME):latest-$(ARCH) $(call unescapefs,$*/$(CONTAINER_BASENAME):$(IMAGETAG)-$(ARCH))
+	docker tag $(DIND_CONTAINER_NAME):latest-$(ARCH) $(call unescapefs,$*/$(DIND_CONTAINER_BASENAME):$(IMAGETAG)-$(ARCH))
 ifeq ($(ARCH),amd64)
 	docker tag $(CONTAINER_NAME):latest-$(ARCH) $(call unescapefs,$*/$(CONTAINER_BASENAME):$(IMAGETAG))
+	docker tag $(DIND_CONTAINER_NAME):latest-$(ARCH) $(call unescapefs,$*/$(DIND_CONTAINER_BASENAME):$(IMAGETAG))
 endif
 
 

--- a/Makefile.calico
+++ b/Makefile.calico
@@ -39,6 +39,9 @@ BINARIES = $(addprefix dist/$(ARCH)/,$(BINARIES_FILES))
 CONTAINER_BASENAME ?= bird
 CONTAINER_NAME ?= calico/$(CONTAINER_BASENAME)
 
+DIND_CONTAINER_BASENAME ?= bird-dind
+DIND_CONTAINER_NAME ?= calico/$(DIND_CONTAINER_BASENAME)
+
 # Version of this repository as reported by git.
 CALICO_GIT_VER := $(shell git describe --tags --dirty --always)
 
@@ -77,6 +80,11 @@ $(CONTAINER_NAME): $(BINARIES)
 image-all: $(addprefix sub-image-,$(VALIDARCHES))
 sub-image-%:
 	$(MYMAKE) image ARCH=$*
+
+.PHONY: dind-image
+dind-image: $(DIND_CONTAINER_NAME)
+$(DIND_CONTAINER_NAME): $(BINARIES)
+	docker build -t $(DIND_CONTAINER_NAME):latest-$(ARCH) -f dind-image/Dockerfile.$(ARCH) dist/$(ARCH)
 
 ## push one arch
 push: imagetag $(addprefix sub-single-push-,$(call escapefs,$(DOCKER_REPOS)))

--- a/dind-image/Dockerfile.amd64
+++ b/dind-image/Dockerfile.amd64
@@ -1,0 +1,29 @@
+FROM docker:stable-dind
+MAINTAINER Pedro Coutinho <pedro@projectcalico.org>
+
+# Copy our binaries
+COPY * /
+
+# Link binaries to standard places /usr/sbin and /usr/bin
+RUN ln -s /bird /usr/sbin/bird
+RUN ln -s /bird6 /usr/sbin/bird6
+RUN ln -s /birdcl /usr/bin/birdcl
+RUN ln -s /birdcl6 /usr/bin/birdcl6
+
+# Create dirs needed for BIRD runtime
+RUN mkdir -p /etc/bird
+RUN mkdir -p /etc/bird6
+RUN mkdir -p /usr/local/var/run
+RUN mkdir -p /usr/local/etc
+
+# Copy in global BIRD and BIRD6 configs
+ADD birdy/bird.conf /etc/bird.conf
+ADD birdy/bird6.conf /etc/bird6.conf
+RUN ln -s /etc/bird.conf /usr/local/etc/bird.conf
+RUN ln -s /etc/bird6.conf /usr/local/etc/bird6.conf
+
+# Copy in a startup script
+ADD birdy/bird-wrapper.sh /opt/bird-wrapper.sh
+ADD birdy/dind-bird-wrapper.sh /opt/dind-bird-wrapper.sh
+ENTRYPOINT ["/opt/dind-bird-wrapper.sh"]
+CMD []

--- a/dist/amd64/birdy/dind-bird-wrapper.sh
+++ b/dist/amd64/birdy/dind-bird-wrapper.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+
+nohup /usr/local/bin/dockerd-entrypoint.sh &
+
+/bin/sh /opt/bird-wrapper.sh


### PR DESCRIPTION
## Description
Add dind (docker-in-docker) + bird container image. This is needed to emulate external networks connected to external bird instances for node STs.

## Todos
- [ ] Unit tests (full coverage)
- [ ] Integration tests (delete as appropriate) In plan/Not needed/Done
- [ ] Documentation
- [ ] Backport
