### PR TITLE
Fix building dind-image

### DIFF
--- a/Makefile.calico
+++ b/Makefile.calico
@@ -80,6 +80,7 @@ $(CONTAINER_NAME): $(BINARIES)
 image-all: $(addprefix sub-image-,$(VALIDARCHES))
 sub-image-%:
 	$(MYMAKE) image ARCH=$*
+	$(MYMAKE) dind-image ARCH=$*
 
 .PHONY: dind-image
 dind-image: $(DIND_CONTAINER_NAME)

--- a/dind-image/Dockerfile
+++ b/dind-image/Dockerfile
@@ -1,0 +1,6 @@
+FROM scratch
+MAINTAINER Pedro Coutinho <pedro@projectcalico.org>
+
+# Copy our binaries
+COPY * /
+

--- a/dind-image/Dockerfile.arm64
+++ b/dind-image/Dockerfile.arm64
@@ -1,0 +1,1 @@
+Dockerfile

--- a/dind-image/Dockerfile.armv7
+++ b/dind-image/Dockerfile.armv7
@@ -1,0 +1,1 @@
+Dockerfile

--- a/dind-image/Dockerfile.ppc64le
+++ b/dind-image/Dockerfile.ppc64le
@@ -1,0 +1,1 @@
+Dockerfile

--- a/dind-image/Dockerfile.s390x
+++ b/dind-image/Dockerfile.s390x
@@ -1,0 +1,1 @@
+Dockerfile


### PR DESCRIPTION
## Description

Follow-on to https://github.com/projectcalico/bird/pull/106 since after merging image building+pushing failed on CD (dind-image images were not being built and arches other than amd64 weren't either).

## Todos
- [ ] Unit tests (full coverage)
- [ ] Integration tests (delete as appropriate) In plan/Not needed/Done
- [ ] Documentation
- [ ] Backport
