### PR TITLE
Remove pushing to quay.io repo

### DIFF
--- a/Makefile.calico
+++ b/Makefile.calico
@@ -52,7 +52,7 @@ escapefs = $(subst :,---,$(subst /,___,$(1)))
 unescapefs = $(subst ---,:,$(subst ___,/,$(1)))
 
 # Variables for controlling image tagging and pushing.
-DOCKER_REPOS=calico quay.io/calico
+DOCKER_REPOS=calico
 ifeq ($(RELEASE),true)
 # If this is a release, also tag and push GCR images.
 DOCKER_REPOS+=gcr.io/projectcalico-org eu.gcr.io/projectcalico-org asia.gcr.io/projectcalico.org us.gcr.io/projectcalico.org


### PR DESCRIPTION
## Description
Remove pushing to quay.io repo from Makefile. I intentionally left quay.io login in semaphore.yaml because I think there's no harm in having it there.

## Todos
- [ ] Unit tests (full coverage)
- [ ] Integration tests (delete as appropriate) In plan/Not needed/Done
- [ ] Documentation
- [ ] Backport
