### PR TITLE
Use alpine:3.17 for calico/bird image instead of alpine:edge

### DIFF
--- a/docker-image/Dockerfile.amd64
+++ b/docker-image/Dockerfile.amd64
@@ -1,4 +1,4 @@
-FROM alpine:edge
+FROM alpine:3.17
 MAINTAINER Neil Jerram <neil@projectcalico.org>
 
 # Copy our binaries


### PR DESCRIPTION
## Description
currently running `ip route` from the `iproute2` package on alpine:edge (6.2.0-r2) is segfaulting, using alpine 3.17 fixes that problem

## Todos
- [ ] Unit tests (full coverage)
- [ ] Integration tests (delete as appropriate) In plan/Not needed/Done
- [ ] Documentation
- [ ] Backport
