### PR TITLE
Remove interfaces that are flagged as shutdown.

### DIFF
--- a/nest/iface.c
+++ b/nest/iface.c
@@ -363,13 +363,15 @@ if_end_partial_update(struct iface *i)
 void
 if_end_update(void)
 {
-  struct iface *i;
+  struct iface *i, *j;
   struct ifa *a, *b;
 
-  WALK_LIST(i, iface_list)
+  WALK_LIST_DELSAFE(i, j, iface_list)
     {
-      if (!(i->flags & IF_UPDATED))
+      if (!(i->flags & IF_UPDATED)) {
 	if_change_flags(i, (i->flags & ~IF_ADMIN_UP) | IF_SHUTDOWN);
+        rem_node(&i->n);
+      }
       else
 	{
 	  WALK_LIST_DELSAFE(a, b, i->addrs)


### PR DESCRIPTION
## Description
Proposal for an additional fix for https://github.com/projectcalico/bird/issues/95.
PR https://github.com/projectcalico/bird/pull/104 already improved the situation a lot, as most deleted interfaces are removed from the list.
However, over time the list is still slowly growing in clusters with a high amount of pod creations and deletions.
This PR deletes all interfaces that disappeared, instead of just flagging as `SHUTDOWN`.
