### PR TITLE
Remove spammy debug log message for DOWN interfaces

### DIFF
--- a/sysdep/linux/netlink.c
+++ b/sysdep/linux/netlink.c
@@ -747,7 +747,6 @@ nl_parse_addr(struct nlmsghdr *h, int scan)
 
   if (!(ifi->flags & IF_ADMIN_UP)) /* Ignore addresses for DOWN interfaces. */
     {
-      log(L_DEBUG "KIF: Ignore %s that is not UP", ifi->name);
       return;
     }
 


### PR DESCRIPTION
Fixes https://github.com/projectcalico/calico/issues/8378

This PR removes the debug log message introduced in [[proto/device] Ignore addr updates on DOWN ifcs](https://github.com/projectcalico/bird/commit/3d15998f2410ff7043dbaa96879e2d9a11b1c3dc), that is very spammy in `kube-proxy` `ipvs` mode clusters because of the `DOWN` `kube-ipvs0` interface, as reported in https://github.com/projectcalico/calico/issues/8378.

After this PR is merged, and the image built and pushed, we'll also need to update the `calico/bird` version / tag in https://github.com/projectcalico/calico/blob/a684f90bec0bc99ccade9424d2312ac641ffd3dd/metadata.mk#L28-L29 .