### PR TITLE
Add null checks for iface before accessing index in mpnh_compare_node

### DIFF
--- a/nest/rt-attr.c
+++ b/nest/rt-attr.c
@@ -234,6 +234,11 @@ mpnh_compare_node(struct mpnh *x, struct mpnh *y)
   if (r)
     return r;
 
+  if (!x->iface)
+    return 1;
+  if (!y->iface)
+    return -1;
+
   return ((int) x->iface->index) - ((int) y->iface->index);
 }
 


### PR DESCRIPTION
## Description

This PR fixes https://github.com/projectcalico/bird/issues/116, which is a segfault in `mpnh_compare_node` by validating that x->iface  and y->iface are not null before accessing their index field.

Null interfaces are treated as greater than non-null ones, consistent with the existing null handling pattern for x and y nodes.

Tested on my machine that was crashing. After replacing the binary in the running pod by the patched one from my branch, there is no more segfault (it was crashing every second in my pod)

<img width="1921" height="579" alt="image" src="https://github.com/user-attachments/assets/f95bb279-94a8-4946-8038-6f2303f56d1e" />

