### PR TITLE
Revive BIRD CI

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -6,12 +6,15 @@ execution_time_limit:
 
 agent:
   machine:
-    type: e1-standard-2
-    os_image: ubuntu2004
+    type: f1-standard-2
+    os_image: ubuntu2204
 
 global_job_config:
   secrets:
-  - name: docker-hub
+    - name: docker-hub
+  env_vars:
+    - name: BUILDKIT_PROGRESS
+      value: plain
   prologue:
     commands:
       - echo $DOCKERHUB_PASSWORD | docker login --username "$DOCKERHUB_USERNAME" --password-stdin

--- a/Makefile.calico
+++ b/Makefile.calico
@@ -71,7 +71,9 @@ do-build:
 
 
 build-all:
-	ARCH=all ./build.sh
+	for tgt in amd64 aarch64 armv7 powerpc64le s390x mips64el; do \
+		ARCH=$${tgt} ./build.sh; \
+	done
 
 image: $(CONTAINER_NAME)
 $(CONTAINER_NAME): $(BINARIES)

--- a/build.sh
+++ b/build.sh
@@ -38,12 +38,9 @@ case $BUILDARCH in
 		exit 1
 		;;
 esac
-	
+
 # get the correct TARGETARCH
 case $ARCH in
-	all)
-		TARGETARCH="amd64 aarch64 armv7 powerpc64le s390x mips64el"
-		;;
 	amd64|x86_64)
 		TARGETARCH=$ARCH
 		;;
@@ -73,6 +70,9 @@ IMAGE=birdbuild-$ARCH
 if [ "$BUILDARCH" != "$TARGETARCH" ]; then
 	DOCKERFILE=Dockerfile-cross
 	IMAGE=birdbuild-$BUILDARCH-cross
+        if [ "$TARGETARCH" = mips64el ]; then
+	        DOCKERFILE=Dockerfile-cross-mips64el
+        fi
 fi
 
 
@@ -83,6 +83,6 @@ docker build -t $IMAGE -f builder-images/$DOCKERFILE .
 mkdir -p $DIST
 # create_binaries expects:
 #    ARCH = architecture on which I am running
-#    TARGETARCH = architecture(s) for which I am building, if different than ARCH (blank if the same) 
+#    TARGETARCH = architecture(s) for which I am building, if different than ARCH (blank if the same)
 #    DIST = root directory in which to put binaries, structured as $DIST/$TARGETARCH
 docker run --rm --name bird-build -e ARCH=$BUILDARCH -e TARGETARCH="$TARGETARCH" -e DIST=$DIST -e OBJ=$OBJ -v `pwd`:/code $IMAGE ./create_binaries.sh

--- a/builder-images/Dockerfile-cross
+++ b/builder-images/Dockerfile-cross
@@ -1,18 +1,16 @@
 FROM gcc:latest
-MAINTAINER Tom Denham <tom@projectcalico.org>
+LABEL maintainer="maintainers@tigera.io"
 
 RUN dpkg --add-architecture arm64
 RUN dpkg --add-architecture armhf
 RUN dpkg --add-architecture ppc64el
 RUN dpkg --add-architecture s390x
-RUN dpkg --add-architecture mips64el
 RUN apt update
 RUN apt-get --no-install-recommends install -y autoconf flex bison \
 	libncurses-dev libreadline-dev \
 	binutils-aarch64-linux-gnu gcc-aarch64-linux-gnu libncurses-dev:arm64 libreadline-dev:arm64 \
 	binutils-powerpc64le-linux-gnu gcc-powerpc64le-linux-gnu libncurses-dev:ppc64el libreadline-dev:ppc64el \
 	binutils-s390x-linux-gnu gcc-s390x-linux-gnu libncurses-dev:s390x libreadline-dev:s390x \
-	binutils-mips64el-linux-gnuabi64 gcc-mips64el-linux-gnuabi64 libncurses-dev:mips64el libreadline-dev:mips64el \
 	binutils-arm-linux-gnueabi gcc-arm-linux-gnueabihf libncurses-dev:armhf libreadline-dev:armhf
 
 WORKDIR /code

--- a/builder-images/Dockerfile-cross-mips64el
+++ b/builder-images/Dockerfile-cross-mips64el
@@ -1,0 +1,10 @@
+FROM gcc:13-bookworm
+LABEL maintainer="maintainers@tigera.io"
+
+RUN dpkg --add-architecture mips64el
+RUN apt update
+RUN apt-get --no-install-recommends install -y autoconf flex bison \
+	libncurses-dev libreadline-dev \
+	binutils-mips64el-linux-gnuabi64 gcc-mips64el-linux-gnuabi64 libncurses-dev:mips64el libreadline-dev:mips64el
+
+WORKDIR /code


### PR DESCRIPTION
BIRD CI was no longer working because:

1. Semaphore OS image ubuntu2004 is no available.

2. For ubuntu2204, machine type e1-standard-2 is not available.

3. Debian trixie dropped support for mips64el arch.  In order to test build for mips64el arch, we need to drop back to cross-compiling using Debian bookworm.  Note, we don't support mips64el in the wider Calico project, so this is only an arch support test for the basic BIRD code.
